### PR TITLE
CMS needs libgfortran for producing madgraph5 gridpacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN yum -y install cvmfs \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
                    e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
-                   libcom_err libaio && \
+                   libcom_err libaio \
+                   libgfortran && \
     yum clean all
 
 # Various directories needed for bind mounts (as overlayfs is not available on RHEL6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ RUN yum -y install cvmfs \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
                    e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
-                   libcom_err libaio \
-                   libgfortran && \
+                   libcom_err libaio libgfortran && \
     yum clean all
 
 # Various directories needed for bind mounts (as overlayfs is not available on RHEL6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN yum -y install cvmfs \
                    ncurses-libs perl-libs perl-ExtUtils-Embed fontconfig \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
-                   e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
-                   libgfortran \
+                   e2fsprogs-libs libXi libXinerama libXft libXrender libXpm libgfortran \
                    libcom_err libaio && \
     yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum -y install cvmfs \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
                    e2fsprogs-libs libgfortran libXi libXinerama libXft libXrender libXpm \
-                   libcom_err && \
+                   libcom_err libaio && \
     yum clean all
 
 # Various directories needed for bind mounts (as overlayfs is not available on RHEL6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN yum -y install cvmfs \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
                    e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
                    libgfortran \
-                   libcom_err && \
+                   libcom_err libaio && \
     yum clean all
 
 # Various directories needed for bind mounts (as overlayfs is not available on RHEL6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ RUN yum -y install cvmfs \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
                    e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
-                   libgfortran \
                    libcom_err libaio && \
     yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ LABEL maintainer="Brian Bockelman"
 # - sssd-client for LDAP lookups through the host
 # - SAM tests expect cvmfs utilities
 # - gcc is required by GLOW jobs (builds matplotlib)
+# - 7 Feb 2018: libaio was added to enable the Oracle client, needed for T0 jobs.
 #
 # CMSSW dependencies
 # ------------------
@@ -33,6 +34,7 @@ RUN yum -y install cvmfs \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
                    e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
+                   libgfortran \
                    libcom_err libaio && \
     yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yum -y install cvmfs \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
                    e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
-                   libcom_err libaio libgfortran && \
+                   libcom_err libaio && \
     yum clean all
 
 # Various directories needed for bind mounts (as overlayfs is not available on RHEL6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN yum -y install cvmfs \
                    ncurses-libs perl-libs perl-ExtUtils-Embed fontconfig \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
-                   e2fsprogs-libs libgfortran libXi libXinerama libXft libXrender libXpm \
+                   e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
+                   libgfortran \
                    libcom_err && \
     yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum -y install cvmfs \
                    ncurses-libs perl-libs perl-ExtUtils-Embed fontconfig \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
-                   e2fsprogs-libs libXi libXinerama libXft libXrender libXpm libgfortran \
+                   e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
                    libcom_err libaio && \
     yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yum -y install cvmfs \
                    ncurses-libs perl-libs perl-ExtUtils-Embed fontconfig \
                    compat-libstdc++-33 libidn libX11 libXmu libSM libICE \
                    libXcursor libXext libXrandr libXft mesa-libGLU mesa-libGL \
-                   e2fsprogs-libs libXi libXinerama libXft libXrender libXpm \
+                   e2fsprogs-libs libgfortran libXi libXinerama libXft libXrender libXpm \
                    libcom_err && \
     yum clean all
 


### PR DESCRIPTION
@bbockelm can you merge, also I think your image should be building from https://github.com/opensciencegrid/osgvo-el6/blob/master/Dockerfile

Which Mats maintains rather than the other one.