### PR TITLE
added /storage special mount for cnaf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,6 @@ RUN mkdir -p /hdfs \
              /hadoop \
              /cms \
              /etc/cvmfs/SITECONF \
-             /lfs_roots
+             /lfs_roots \
+             /storage
 


### PR DESCRIPTION
Hello,
CNAF is a multi-VO site and local system administrators are not willing to add a special binding /cms in the WN for the gpfs posix file system. See ticket:

https://ggus.eu/index.php?mode=ticket_info&ticket_id=135045

This implies that within singularity we are currently relying on the xrootd fallback with a sizable loss of efficiency.
We need therefore to add an exception in the glideinWMS validation and wrapper scripts, adding  the "/storage" mount point (used by CNAF), among the "special" ones.