### PR TITLE
Create .singularity.d

### DIFF
--- a/.singularity.d/actions/exec
+++ b/.singularity.d/actions/exec
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+exec "$@"
+

--- a/.singularity.d/actions/run
+++ b/.singularity.d/actions/run
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -x /.singularity.d/runscript; then
+    exec /.singularity.d/runscript "$@"
+else
+    echo "No Singularity runscript found, executing /bin/sh"
+    exec /bin/sh "$@"
+fi
+

--- a/.singularity.d/actions/shell
+++ b/.singularity.d/actions/shell
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -n "$SINGULARITY_SHELL" -a -x "$SINGULARITY_SHELL"; then
+    exec $SINGULARITY_SHELL "$@"
+
+    echo "ERROR: Failed running shell as defined by '\$SINGULARITY_SHELL'" 1>&2
+    exit 1
+
+elif test -x /bin/bash; then
+    SHELL=/bin/bash
+    PS1="Singularity $SINGULARITY_CONTAINER:\\w> "
+    export SHELL PS1
+    exec /bin/bash --norc "$@"
+elif test -x /bin/sh; then
+    SHELL=/bin/sh
+    export SHELL
+    exec /bin/sh "$@"
+else
+    echo "ERROR: /bin/sh does not exist in container" 1>&2
+fi
+exit 1
+

--- a/.singularity.d/actions/test
+++ b/.singularity.d/actions/test
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+for script in /.singularity.d/env/*.sh; do
+    if [ -f "$script" ]; then
+        . "$script"
+    fi
+done
+
+if test -x /.singularity.d/test; then
+    exec /.singularity.d/test "$@"
+else
+    echo "No Singularity container test found, executing /bin/sh"
+    exec /bin/sh "$@"
+fi
+

--- a/.singularity.d/env/90-environment.sh
+++ b/.singularity.d/env/90-environment.sh
@@ -1,0 +1,8 @@
+# Custom environment shell code should follow
+#
+#if [ "x$LD_LIBRARY_PATH" = "x" ]; then
+#    export LD_LIBRARY_PATH="/host-libs"
+#else
+#    export LD_LIBRARY_PATH="/host-libs:$LD_LIBRARY_PATH"
+#fi
+

--- a/.singularity.d/env/90-environment.sh~
+++ b/.singularity.d/env/90-environment.sh~
@@ -1,0 +1,8 @@
+# Custom environment shell code should follow
+
+if [ "x$LD_LIBRARY_PATH" = "x" ]; then
+    export LD_LIBRARY_PATH="/host-libs"
+else
+    export LD_LIBRARY_PATH="/host-libs:$LD_LIBRARY_PATH"
+fi
+

--- a/.singularity.d/env/90-environment.sh~
+++ b/.singularity.d/env/90-environment.sh~
@@ -1,8 +1,0 @@
-# Custom environment shell code should follow
-
-if [ "x$LD_LIBRARY_PATH" = "x" ]; then
-    export LD_LIBRARY_PATH="/host-libs"
-else
-    export LD_LIBRARY_PATH="/host-libs:$LD_LIBRARY_PATH"
-fi
-

--- a/.singularity.d/runscript
+++ b/.singularity.d/runscript
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+exec /bin/bash "$@"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN yum -y install cvmfs \
                    gcc \
                    glibc-headers \
                    openssh-clients \
+                   openssh-server \
                    redhat-lsb-core \
                    sssd-client && \
     yum -y install glibc coreutils bash tcsh zsh perl tcl tk readline openssl \


### PR DESCRIPTION
This is the first step to make sure `condor_ssh_to_job` can ssh into singularity. OTherwise we get errors like:

```WARNING: Not mounting /hadoop (already mounted in container)
WARNING: Container does not have an exec helper script, calling '/srv/.osgvo-user-job-wrapper.sh' directly
/srv/.osgvo-user-job-wrapper.sh: line 425: /usr/sbin/sshd: No such file or directory
/srv/.osgvo-user-job-wrapper.sh: line 425: exec: /usr/sbin/sshd: cannot execute: No such file or directory
```